### PR TITLE
Added notice regarding CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Here's how it works:
     ```
     You can also use `g++` and `clang++` to run the respective MSYS2 compilers in Wine, assuming you installed `_gcc` and `_clang` respectively.
   * With Autotools: `./configure && make` as usual, no extra configuration is needed.
-  * With CMake: `cmake` as usual.
+  * With CMake: Install `cmake` on the host system, afterwards `cmake` can be used as usual.
   * With Meson: `meson` as usual.
 
 * Other tools that work in `env/shell.sh`:


### PR DESCRIPTION
I installed `quasi-msys2` in a Docker container and was assuming for quite a bit too long that cmake would come with `quasi-msys2`. As such, I suggest adding a small notice that `cmake` has to be installed on the host system.

